### PR TITLE
remove whitespace from json minimisation

### DIFF
--- a/packages/typechain-polkadot/src/utils/json.ts
+++ b/packages/typechain-polkadot/src/utils/json.ts
@@ -3,6 +3,6 @@
  * @param json - JSON string
  */
 export function minimizeJson(json: string): string {
-    // remove whitespace as it causes issues when parsing JSON
-	return JSON.stringify(JSON.parse(json)).replace(/\\n/g, '').replace(/\\r/g, '').replace(/\\t/g, '')
+	// remove whitespace as it causes issues when parsing JSON
+	return JSON.stringify(JSON.parse(json)).replace(/\\n/g, '').replace(/\\r/g, '').replace(/\\t/g, '');
 }

--- a/packages/typechain-polkadot/src/utils/json.ts
+++ b/packages/typechain-polkadot/src/utils/json.ts
@@ -3,5 +3,6 @@
  * @param json - JSON string
  */
 export function minimizeJson(json: string): string {
-	return JSON.stringify(JSON.parse(json));
+    // remove whitespace as it causes issues when parsing JSON
+	return JSON.stringify(JSON.parse(json)).replace(/\\n/g, '').replace(/\\r/g, '').replace(/\\t/g, '')
 }


### PR DESCRIPTION
Whitespace is causing an issue with json parsing as the newlines are not escaped. Rather than faffing around with escaping them potentially many times, it's easiest to remove the whitespace